### PR TITLE
Refactor RB code to use the new Clifford operator class

### DIFF
--- a/qiskit/ignis/verification/randomized_benchmarking/rb_groups.py
+++ b/qiskit/ignis/verification/randomized_benchmarking/rb_groups.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Methods for handling groups (Clifford, CNOT Dihedral etc.)
+in randomized benchmarking"""
+
+import numpy as np
+from qiskit.exceptions import QiskitError
+from  qiskit.quantum_info.operators.symplectic import Clifford
+from qiskit.quantum_info.random import random_clifford
+from .dihedral import CNOTDihedral, random_cnotdihedral
+
+
+class RBgroup():
+    """Class that handles the group operations needed for RB."""
+
+    def __init__(self, num_qubits, group_gates):
+        """Initialization from num_qubits and group_gates"""
+        self.num_qubit = num_qubits
+        self.group_gates = group_gates
+
+        if group_gates is None or group_gates in ('0',
+                                                  'Clifford',
+                                                  'clifford'):
+            self.rb_group = Clifford
+            self.rb_circ_type = 'rb'
+            self.group_gates_type = 0
+        elif group_gates in ('1', 'Non-Clifford',
+                             'NonClifford'
+                             'CNOTDihedral',
+                             'CNOT-Dihedral'):
+            self.rb_group = CNOTDihedral
+            self.rb_circ_type = 'rb_cnotdihedral'
+            self.group_gates_type = 1
+        else:
+            raise QiskitError("Unknown group or set of gates.")
+
+    def iden(self):
+        """Initialize an identity group element"""
+        if self.group_gates_type:
+            return CNOTDihedral(self.num_qubits)
+        else:
+            return Clifford(np.eye(2 * self.num_qubits))
+
+    def random(self):
+        """Generate a random group element"""
+        if self.group_gates_type:
+            return random_cnotdihedral(self.num_qubits)
+        else:
+            return random_clifford(self.num_qubits)
+
+    def compose(self, orig, other):
+        """Compose two group elements: orig and other"""
+        orig_elem = self.rb_group(orig)
+        other_elem = self.rb_group(other)
+        return orig_elem.compose(other_elem)
+
+    def inverse(self, orig):
+        """Computes the inverse QuantumCircuit"""
+        elem = self.rb_group(orig)
+        # decompose the group element into a QuantumCircuit
+        circ = elem.to_circuit()
+        # invert the QuantumCircuit
+        return (circ.inverse())
+
+    def to_circuit(self, orig):
+        """Returns the corresponding QuantumCircuit"""
+        elem = self.rb_group(orig)
+        return elem.to_circuit()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Refactor RB code to use the new Clifford operator class in Terra quantum_info and the updated CNOTDihedral class: #392
Depends on #394


### Details and comments
- [x] Add a new class: `RBgroup` that handles the group methods needed for RB
- [ ] Remove the files: `Clifford.py`, `clifford_utils.py`, `dihedral_utils.py`,` basic_utils.py` and `test_clifford.py`
- [ ] Refactor `circuit.py` so that it will use `RBgroup` class
- [ ] Refactor `rb_test.py` to include tests for RB on the Clifford group with more than 2 qubits


